### PR TITLE
feat: add AsyncImage.ShouldTextureBeReadable

### DIFF
--- a/Runtime/Core/AsyncImage.cs
+++ b/Runtime/Core/AsyncImage.cs
@@ -29,6 +29,9 @@ namespace AsyncImageLibrary
         private bool shouldQueueTextureProcess = false;
         public bool ShouldQueueTextureProcess { get => shouldQueueTextureProcess; set => shouldQueueTextureProcess = value; }
 
+        private bool shouldTextureBeReadable = false;
+        public bool ShouldTextureBeReadable { get => shouldTextureBeReadable; set => shouldTextureBeReadable = value; }
+        
         private bool? isPathValidated;
         public bool? IsPathValidated { get => isPathValidated; internal set => isPathValidated = value; }
 

--- a/Runtime/Core/ImageProcess.cs
+++ b/Runtime/Core/ImageProcess.cs
@@ -73,7 +73,7 @@ namespace AsyncImageLibrary
                 TextureFormat.RGBA32 : TextureFormat.BGRA32;
             Texture2D texture = new Texture2D(asyncImage.Bitmap.Width, asyncImage.Bitmap.Height, textureFormat, false);
             texture.LoadRawTextureData(asyncImage.Bitmap.GetPixels(), asyncImage.Bitmap.RowBytes * asyncImage.Bitmap.Height);
-            texture.Apply(false, true);
+            texture.Apply(false, !asyncImage.ShouldTextureBeReadable);
             asyncImage.Texture = texture;
             onComplete?.Invoke();
         }


### PR DESCRIPTION
This PR adds a field to AsyncImage.cs to keep textures readable. Solves #4.
Usage:
```
var asyncImage = new AsyncImage(texturePath);
asyncImage.ShouldTextureBeReadable = true;
```